### PR TITLE
multi-arch pause image and Mimir datasource

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   pause:
-    image: k8s.gcr.io/pause:3.1
+    image: registry.k8s.io/pause:3.9
     networks:
     - bookshelf
 

--- a/observation/grafana/compose.yaml
+++ b/observation/grafana/compose.yaml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   grafana:
-    image: grafana/grafana:9.3.2
+    image: grafana/grafana:9.3.6
     environment:
       GF_SECURITY_ADMIN_USER: admin
       GF_SECURITY_ADMIN_PASSWORD: SuperSecr3t

--- a/observation/grafana/configs/provisioning/datasources/mimir.yml
+++ b/observation/grafana/configs/provisioning/datasources/mimir.yml
@@ -1,0 +1,5 @@
+apiVersion: 1
+datasources:
+- name: Mimir
+  type: prometheus
+  url: http://mimir:9009/prometheus

--- a/observation/mimir/compose.yaml
+++ b/observation/mimir/compose.yaml
@@ -2,12 +2,13 @@ version: "3.7"
 
 services:
   mimir:
-    image: grafana/mimir:2.5.0
+    image: grafana/mimir:2.6.0
     command:
     - -target=all,alertmanager
     - -config.file=/etc/mimir/config.yaml
     ports:
     - 9009:9009
+    - 9095:9095
     volumes:
     - ./configs:/etc/mimir
     - mimir_data:/mimir_data


### PR DESCRIPTION
The `k8s.gcr.io/pause:3.1` wasn't multi-arch.